### PR TITLE
Fetch

### DIFF
--- a/lib/docker-client.ts
+++ b/lib/docker-client.ts
@@ -423,11 +423,10 @@ export class DockerClient {
             `/containers/${id}/attach`,
             options,
         );
-        const contentType = response.headers.get('content-type');
-        if (contentType === 'application/vnd.docker.raw-stream') {
-            response.body?.pipeTo(Writable.toWeb(stdout));
+        if (response.content === 'application/vnd.docker.raw-stream') {
+            response.socket.pipe(stdout);
         } else {
-            response.body?.pipeTo(demultiplexStream(stdout, stderr));
+            response.socket.pipe(demultiplexStream(stdout, stderr));
         }
     }
 
@@ -597,7 +596,7 @@ export class DockerClient {
                 options,
             )
             .then((response) => {
-                response.body?.pipeTo(demux);
+                response.body?.pipeTo(Writable.toWeb(demux));
             });
     }
 

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -161,10 +161,7 @@ export class HTTPClient {
         });
     }
 
-    public async getJSON<T>(
-        uri: string,
-        params?: Record<string, any>,
-    ): Promise<T> {
+    public getJSON<T>(uri: string, params?: Record<string, any>): Promise<T> {
         return this.get(uri, APPLICATION_JSON, params).then((response) => {
             if (response.status === 404) {
                 throw NotFoundError;
@@ -271,6 +268,6 @@ interface Upgrade {
     socket: Duplex;
 }
 
-function isReadableStream(data: unknown): data is ReadableStream {
+function isReadableStream(data: any): data is ReadableStream {
     return 'getReader' in data && typeof data.getReader === 'function';
 }

--- a/lib/json-stream.ts
+++ b/lib/json-stream.ts
@@ -1,0 +1,43 @@
+import { WritableStream } from 'node:stream/web';
+
+export class JSONStream<T> extends WritableStream {
+    private buffer: string = '';
+
+    constructor(onJSON?: (jsonObj: T) => void) {
+        super({
+            write: (chunk: Uint8Array) => {
+                this.processChunk(chunk, onJSON);
+            },
+            close: () => {
+                if (this.buffer.trim() && onJSON) {
+                    this.processLine(this.buffer.trim(), onJSON);
+                }
+            },
+        });
+    }
+
+    private processChunk(
+        chunk: Uint8Array,
+        onJSON?: (jsonObj: any) => void,
+    ): void {
+        const text = new TextDecoder().decode(chunk);
+        this.buffer += text;
+
+        const lines = this.buffer.split('\n');
+        this.buffer = lines.pop() || '';
+
+        for (const line of lines) {
+            if (line.trim() && onJSON) {
+                this.processLine(line.trim(), onJSON);
+            }
+        }
+    }
+
+    private processLine(line: string, onJSON: (jsonObj: any) => void): void {
+        try {
+            onJSON(JSON.parse(line) as T);
+        } catch (error) {
+            console.error(`Failed to parse JSON line: ${line}`, error);
+        }
+    }
+}

--- a/lib/multiplexed-stream.ts
+++ b/lib/multiplexed-stream.ts
@@ -1,14 +1,18 @@
-import { WritableStream } from 'node:stream/web';
-import type { Writable } from 'node:stream';
+import { Writable } from 'node:stream';
+import stream from 'node:stream';
 
 export function demultiplexStream(
-    stdout: Writable,
-    stderr: Writable,
-): WritableStream {
+    stdout: NodeJS.WritableStream,
+    stderr: NodeJS.WritableStream,
+): stream.Writable {
     let buffer = new Uint8Array(0);
 
-    return new WritableStream({
-        write(chunk: Uint8Array, controller) {
+    return new Writable({
+        write(
+            chunk: any,
+            encoding: BufferEncoding,
+            cb: (error?: Error | null) => void,
+        ) {
             try {
                 // Convert chunk to Uint8Array if needed
                 const data =
@@ -52,20 +56,10 @@ export function demultiplexStream(
                         break;
                     }
                 }
+                cb();
             } catch (error) {
-                controller.error(
-                    error instanceof Error ? error : new Error(String(error)),
-                );
+                cb(error as Error);
             }
-        },
-
-        close() {
-            // Stream is being closed, nothing special to do
-        },
-
-        abort(reason) {
-            // Stream is being aborted
-            console.error('Demultiplex stream aborted:', reason);
         },
     });
 }

--- a/lib/multiplexed-stream.ts
+++ b/lib/multiplexed-stream.ts
@@ -1,25 +1,24 @@
-import * as stream from 'node:stream';
+import { WritableStream } from 'node:stream/web';
+import type { Writable } from 'node:stream';
 
 export function demultiplexStream(
-    stdout: stream.Writable,
-    stderr: stream.Writable,
-): stream.Writable {
-    let buffer = Buffer.alloc(0);
+    stdout: Writable,
+    stderr: Writable,
+): WritableStream {
+    let buffer = new Uint8Array(0);
 
-    return new stream.Writable({
-        write(
-            chunk: any,
-            encoding: BufferEncoding,
-            callback: (error?: Error | null) => void,
-        ) {
+    return new WritableStream({
+        write(chunk: Uint8Array, controller) {
             try {
-                // Convert chunk to Buffer if it's not already
-                const data = Buffer.isBuffer(chunk)
-                    ? chunk
-                    : Buffer.from(chunk, encoding);
+                // Convert chunk to Uint8Array if needed
+                const data =
+                    chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
 
                 // Append new chunk data to buffer
-                buffer = Buffer.concat([buffer, data]);
+                const newBuffer = new Uint8Array(buffer.length + data.length);
+                newBuffer.set(buffer, 0);
+                newBuffer.set(data, buffer.length);
+                buffer = newBuffer;
 
                 // Process complete messages from buffer
                 while (buffer.length >= 8) {
@@ -27,35 +26,46 @@ export function demultiplexStream(
                     const streamType = buffer[0];
 
                     // Read last 4 bytes as content size (big endian uint32)
-                    const contentSize = buffer.readUInt32BE(4);
+                    const contentSize =
+                        (buffer[4]! << 24) |
+                        (buffer[5]! << 16) |
+                        (buffer[6]! << 8) |
+                        buffer[7]!;
 
                     // Check if we have enough data for the complete message
                     if (buffer.length >= 8 + contentSize) {
                         // Extract content
-                        const content = buffer.subarray(8, 8 + contentSize);
+                        const content = buffer.slice(8, 8 + contentSize);
 
                         // Send to appropriate stream
                         if (streamType === 1) {
-                            stdout.write(content);
+                            stdout.write(Buffer.from(content));
                         } else if (streamType === 2) {
-                            stderr.write(content);
+                            stderr.write(Buffer.from(content));
                         }
                         // Ignore other stream types
 
                         // Remove processed message from buffer
-                        buffer = buffer.subarray(8 + contentSize);
+                        buffer = buffer.slice(8 + contentSize);
                     } else {
                         // Not enough data for complete message, wait for more
                         break;
                     }
                 }
-
-                callback();
             } catch (error) {
-                callback(
+                controller.error(
                     error instanceof Error ? error : new Error(String(error)),
                 );
             }
+        },
+
+        close() {
+            // Stream is being closed, nothing special to do
+        },
+
+        abort(reason) {
+            // Stream is being aborted
+            console.error('Demultiplex stream aborted:', reason);
         },
     });
 }

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,7 @@
 import { DockerClient } from './lib/docker-client.js';
 import { createWriteStream } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { Writable } from 'node:stream';
 
 try {
     const docker = await DockerClient.fromDockerConfig();
@@ -20,7 +21,7 @@ try {
         });
 
     const out = createWriteStream(tmpdir() + '/test.tar');
-    await docker.containerExport(ctr, out);
+    await docker.containerExport(ctr, Writable.toWeb(out));
 
     docker.close();
 } catch (error: any) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "ssh2": "^1.16.0",
-        "tar-stream": "^3.1.4"
+        "tar-stream": "^3.1.4",
+        "undici": "^6.22.0"
       },
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.23.4",
@@ -4751,6 +4752,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
+      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "ssh2": "^1.16.0",
-    "tar-stream": "^3.1.4"
+    "tar-stream": "^3.1.4",
+    "undici": "^6.22.0"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.23.4",
@@ -63,7 +64,7 @@
     "vitest": "^3.2.4"
   },
   "engines": {
-      "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
   },
   "packageManager": "npm@10.9.3"
 }

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 import { DockerClient } from '../lib/docker-client.js';
 import { pack as createTarPack } from 'tar-stream';
 import { fail } from 'node:assert';
+import { Readable } from 'node:stream';
 
 test('imageBuild: build image from Dockerfile with tar-stream context', async () => {
     const client = await DockerClient.fromDockerConfig();
@@ -23,7 +24,7 @@ COPY test.txt /test.txt
         let eventCount = 0;
         const builtImage = await client
             .imageBuild(
-                pack,
+                Readable.toWeb(pack),
                 (event) => {
                     eventCount++;
                     buildEvents.push(event);

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -24,7 +24,7 @@ COPY test.txt /test.txt
         let eventCount = 0;
         const builtImage = await client
             .imageBuild(
-                Readable.toWeb(pack),
+                Readable.toWeb(pack, { strategy: { highWaterMark: 16384 } }),
                 (event) => {
                     eventCount++;
                     buildEvents.push(event);

--- a/test/image.test.ts
+++ b/test/image.test.ts
@@ -63,18 +63,14 @@ test('image lifecycle: create container, commit image, export/import, inspect, a
 
         // Step 3: Get image as tar file
         console.log('  Exporting image as tar file...');
-        const tarData: Buffer[] = [];
+        const tarData: Uint8Array[] = [];
 
         await client.imageGet(
             testImageName,
-            new Writable({
-                write(chunk, encoding, callback) {
-                    const data =
-                        typeof chunk === 'string'
-                            ? Buffer.from(chunk, encoding)
-                            : chunk;
-                    tarData.push(data);
-                    callback();
+            new WritableStream({
+                write(chunk: Uint8Array, controller) {
+                    // console.log(`    Writing chunk: ${chunk.length} bytes`);
+                    tarData.push(chunk);
                 },
             }),
         );
@@ -100,7 +96,7 @@ test('image lifecycle: create container, commit image, export/import, inspect, a
 
         // Step 5: Load image from tar file
         console.log('  Loading image from tar file...');
-        await client.imageLoad(Readable.from(tarBuffer));
+        await client.imageLoad(Readable.toWeb(Readable.from(tarBuffer)));
         console.log('    Image loaded from tar file');
 
         // Step 6: Inspect the loaded image to confirm successful load

--- a/test/image.test.ts
+++ b/test/image.test.ts
@@ -31,6 +31,7 @@ test('image lifecycle: create container, commit image, export/import, inspect, a
             },
         });
 
+        console.dir(createResponse, { depth: null });
         containerId = createResponse.Id;
         assert.isNotNull(containerId);
         console.log(`    Container created: ${containerId.substring(0, 12)}`);


### PR DESCRIPTION
** Work in Progress **

Use [undici](https://github.com/nodejs/undici) for better performances
note: strict HTTP upgrade (a.k.a "http hijack") requires support for `Connection: Upgrade` header which is blocked by Fetch API. Haven't found how to workaround this.

closes https://github.com/docker/node-sdk/issues/23

