### PR TITLE
Fix #31: "should receive container stdout on attach" by ensuring stream data is fully written

### DIFF
--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -91,6 +91,22 @@ test('should receive container stdout on attach', async () => {
         // Wait for container to finish
         console.log('  Waiting for container to finish...');
         const waitResult = await client.containerWait(containerId);
+
+        // Wait for streams to finish writing all data
+        // This ensures all piped data has been written to our Writable streams
+        await new Promise<void>((resolve) => {
+            // Set a timeout in case streams don't emit 'finish' event
+            const timeout = setTimeout(resolve, 1000);
+            
+            // Wait for stdout stream to finish
+            stdout.once('finish', () => {
+                clearTimeout(timeout);
+                resolve();
+            });
+            
+            // Trigger finish by ending the stream
+            stdout.end();
+        });
         console.log(
             `    Container finished with exit code: ${waitResult.StatusCode}`,
         );


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
Fixes #31 "investigate flaky test"

**- How I did it**
Explicitly waiting for stdout stream to finish by calling stream.end() and listening for the 'finish' event. This ensures all piped data has been written to the stdoutData array before any test assertions, which fixes flaky behavior.

**- How to verify it**

Run `npm test -- --run "test/container.test.ts" -t "should receive container stdout on attach"` until you are convinced it is no longer flaky. (I ran it 200 times)

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/f7938817-c9ba-4b10-a36b-e961603534c4" />
