### PR TITLE
Fixed issue exporting Docker API Types

### DIFF
--- a/lib/docker-client.ts
+++ b/lib/docker-client.ts
@@ -237,8 +237,8 @@ export class DockerClient {
         }
     }
 
-    public close() {
-        this.api.close();
+    public close(): Promise<void> {
+        return this.api.close();
     }
 
     // --- Authentication
@@ -294,7 +294,7 @@ export class DockerClient {
             until?: string;
             filters?: Filter;
         },
-    ) {
+    ): Promise<void> {
         const response = await this.api.get('/events', APPLICATION_NDJSON, {
             params: options,
         });

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -88,8 +88,8 @@ export class HTTPClient {
         this.baseUrl = 'http://localhost:2375';
     }
 
-    close() {
-        this.agent.destroy();
+    close(): Promise<void> {
+        return this.agent.destroy();
     }
 
     // Method to send an HTTP request with method, URI and parameters

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,3 +5,4 @@ export * from './multiplexed-stream.js';
 export * from './socket.js';
 export * from './ssh.js';
 export * from './tls.js';
+export * from './types/index.js';

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -25,7 +25,7 @@ export function getErrorMessage(error: unknown): string | undefined {
 export function parseIntWithDefault(
     value: string | undefined,
     defaultValue: number,
-) {
+): number {
     if (value === undefined) {
         return defaultValue;
     }

--- a/test-integration/esm-project/import.test.ts
+++ b/test-integration/esm-project/import.test.ts
@@ -1,7 +1,13 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test, assert, expectTypeOf } from 'vitest';
 
-import { DockerClient } from '@docker/node-sdk';
+import {
+    DockerClient,
+    type ContainerCreateRequest,
+    type ContainerCreateResponse,
+    type NetworkCreateRequest,
+    type NetworkCreateResponse,
+    type SystemInfo,
+} from '@docker/node-sdk';
 
 test('ES module should import correctly', () => {
     assert.equal(typeof DockerClient, 'function');
@@ -13,4 +19,31 @@ test('ES module should import functional client', async () => {
     const apiVersion = await docker.systemPing();
     assert.ok(apiVersion);
     console.log(`  Docker API version: ${apiVersion}`);
+});
+
+test('ES module should export Docker API types', async () => {
+    const docker = await DockerClient.fromDockerConfig();
+
+    expectTypeOf(docker).toEqualTypeOf<DockerClient>();
+
+    expectTypeOf(docker.systemInfo).toBeFunction();
+    expectTypeOf(docker.systemInfo).returns.toEqualTypeOf<
+        Promise<SystemInfo>
+    >();
+
+    expectTypeOf(docker.containerCreate).toBeFunction();
+    expectTypeOf(docker.containerCreate)
+        .parameter(0)
+        .toEqualTypeOf<ContainerCreateRequest>();
+    expectTypeOf(docker.containerCreate).returns.toEqualTypeOf<
+        Promise<ContainerCreateResponse>
+    >();
+
+    expectTypeOf(docker.networkCreate).toBeFunction();
+    expectTypeOf(docker.networkCreate)
+        .parameter(0)
+        .toEqualTypeOf<NetworkCreateRequest>();
+    expectTypeOf(docker.networkCreate).returns.toEqualTypeOf<
+        Promise<NetworkCreateResponse>
+    >();
 });

--- a/test-integration/esm-project/package.json
+++ b/test-integration/esm-project/package.json
@@ -3,12 +3,13 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "test": "tsx --test import.test.ts",
+        "test": "vitest run --typecheck",
         "start": "tsx main.ts"
     },
     "type": "module",
     "dependencies": {
-        "@docker/node-sdk": "file:../.."
+        "@docker/node-sdk": "file:../..",
+        "vitest": "^3.2.4"
     },
     "devDependencies": {
         "@types/node": "^24.5.2",

--- a/test-integration/esm-project/vitest.config.ts
+++ b/test-integration/esm-project/vitest.config.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    test: {
+        include: ['**/*.test.ts'],
+    },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "lib": ["ES2022"],
         "strict": true,
-        "allowJs": true,
+        "allowJs": false,
         "esModuleInterop": true,
         "skipLibCheck": true,
         "moduleResolution": "NodeNext",
@@ -13,6 +13,7 @@
         "rootDir": "./lib",
         "declaration": true,
         "declarationMap": true,
+        "isolatedDeclarations": true,
         "sourceMap": true,
         "allowImportingTsExtensions": true,
         "allowSyntheticDefaultImports": true,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig, type UserConfig } from 'tsdown';
 
 export default defineConfig({
     entry: ['lib/index.ts'],
@@ -18,4 +18,4 @@ export default defineConfig({
     tsconfig: './tsconfig.json',
     nodeProtocol: true,
     skipNodeModulesBundle: false,
-});
+}) as UserConfig;


### PR DESCRIPTION
Fixed promise issue with DockerClient.close()

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
Fixed issue exporting Docker API Types

**- How I did it**
- Explicitly exported types from `./types/index.js`.
- Additionally, enabled `isolatedDeclarations` to support more correct and faster tsd builds.
- Fixed issue with `DockerClient.close()` that didn't use promise to wait until the connection was closed.

**- How to verify it**
- Run tests in `test-integration/esm-project/import.test.ts`

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog
Fixed issue exporting Docker API Types
```

**- A picture of a cute animal (not mandatory but encouraged)**
