### PR TITLE
introduce Logger to consume container logs line by line with a callback

### DIFF
--- a/lib/docker-client.ts
+++ b/lib/docker-client.ts
@@ -391,7 +391,7 @@ export class DockerClient {
     public async containerAttach(
         id: string,
         stdout: stream.Writable,
-        stderr: stream.Writable,
+        stderr: stream.Writable | null,
         options?: {
             detachKeys?: string;
             logs?: boolean;
@@ -408,6 +408,11 @@ export class DockerClient {
         if (response.content === 'application/vnd.docker.raw-stream') {
             response.socket.pipe(stdout);
         } else {
+            if (stderr === null) {
+                throw new Error(
+                    'stderr is required to process multiplexed stream',
+                );
+            }
             response.socket.pipe(demultiplexStream(stdout, stderr));
         }
     }

--- a/lib/logs.ts
+++ b/lib/logs.ts
@@ -1,0 +1,45 @@
+import { Writable } from 'stream';
+
+// Logger handles container logs and calls a callback for each line
+export class Logger extends Writable {
+    private buffer: string = '';
+    private callback: (line: string) => void;
+
+    constructor(callback: (line: string) => void) {
+        super({ objectMode: false });
+        this.callback = callback;
+    }
+
+    override _write(
+        chunk: any,
+        encoding: BufferEncoding,
+        callback: (error?: Error | null) => void,
+    ): void {
+        try {
+            this.buffer += chunk.toString();
+
+            let newlineIndex;
+            while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
+                const line = this.buffer.substring(0, newlineIndex);
+                this.buffer = this.buffer.substring(newlineIndex + 1);
+                this.callback(line);
+            }
+
+            callback();
+        } catch (error) {
+            callback(error instanceof Error ? error : new Error(String(error)));
+        }
+    }
+
+    override _final(callback: (error?: Error | null) => void): void {
+        try {
+            if (this.buffer.length > 0) {
+                this.callback(this.buffer);
+                this.buffer = '';
+            }
+            callback();
+        } catch (error) {
+            callback(error instanceof Error ? error : new Error(String(error)));
+        }
+    }
+}

--- a/test/logs.test.ts
+++ b/test/logs.test.ts
@@ -1,0 +1,66 @@
+import { assert, test, describe } from 'vitest';
+import { Logger } from '../lib/logs.js';
+
+describe('Logger', () => {
+    test('should call callback for each complete line', () => {
+        const lines: string[] = [];
+        const logger = new Logger((line) => {
+            lines.push(line);
+        });
+
+        logger.write('line1\nline2\nline3\n');
+        logger.end();
+
+        assert.deepEqual(lines, ['line1', 'line2', 'line3']);
+    });
+
+    test('should handle partial lines across multiple writes', () => {
+        const lines: string[] = [];
+        const logger = new Logger((line) => {
+            lines.push(line);
+        });
+
+        logger.write('partial');
+        logger.write(' line1\nline2');
+        logger.write('\nline3\n');
+        logger.end();
+
+        assert.deepEqual(lines, ['partial line1', 'line2', 'line3']);
+    });
+
+    test('should handle remaining buffer on end', () => {
+        const lines: string[] = [];
+        const logger = new Logger((line) => {
+            lines.push(line);
+        });
+
+        logger.write('line without newline');
+        logger.end();
+
+        assert.deepEqual(lines, ['line without newline']);
+    });
+
+    test('should handle empty lines', () => {
+        const lines: string[] = [];
+        const logger = new Logger((line) => {
+            lines.push(line);
+        });
+
+        logger.write('line1\n\nline3\n');
+        logger.end();
+
+        assert.deepEqual(lines, ['line1', '', 'line3']);
+    });
+
+    test('should handle only newlines', () => {
+        const lines: string[] = [];
+        const logger = new Logger((line) => {
+            lines.push(line);
+        });
+
+        logger.write('\n\n\n');
+        logger.end();
+
+        assert.deepEqual(lines, ['', '', '']);
+    });
+});


### PR DESCRIPTION
**- What I did**

introduce Logger to consume container logs line by line with a callback
closes https://github.com/docker/node-sdk/issues/26

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

**- A picture of a cute animal (not mandatory but encouraged)**
