### PR TITLE
Added support for attached mode in execStart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,10 +82,9 @@ jobs:
               with:
                   node-version-file: .node-version
                   registry-url: https://npm.pkg.github.com
-                  always-auth: 'true'
+                  always-auth: "true"
 
             - name: Publish (internal)
               if: ${{ ! inputs.dryRun }}
               run: |
                   npm publish --provenance
-

--- a/lib/filter.ts
+++ b/lib/filter.ts
@@ -1,8 +1,8 @@
 export class Filter {
     private data: Map<string, Set<string>> = new Map();
-
-    set(key: string, values: string[]): void {
+    set(key: string, values: string[]): Filter {
         this.data.set(key, new Set(values));
+        return this;
     }
 
     add(key: string, value: string): Filter {

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -4,8 +4,9 @@ import { Agent, Response, fetch, upgrade } from 'undici';
 import { Duplex } from 'stream';
 
 // Docker stream content type constants
-const _DOCKER_RAW_STREAM = 'application/vnd.docker.raw-stream';
-const _DOCKER_MULTIPLEXED_STREAM = 'application/vnd.docker.multiplexed-stream';
+export const DOCKER_RAW_STREAM = 'application/vnd.docker.raw-stream';
+export const DOCKER_MULTIPLEXED_STREAM =
+    'application/vnd.docker.multiplexed-stream';
 export const APPLICATION_JSON = 'application/json';
 export const APPLICATION_NDJSON = 'application/x-ndjson';
 

--- a/lib/logs.ts
+++ b/lib/logs.ts
@@ -15,6 +15,7 @@ export class Logger extends Writable {
         encoding: BufferEncoding,
         callback: (error?: Error | null) => void,
     ): void {
+        console.log(chunk.toString());
         try {
             this.buffer += chunk.toString();
 

--- a/test/exec.test.ts
+++ b/test/exec.test.ts
@@ -1,0 +1,116 @@
+import { assert, test } from 'vitest';
+import { DockerClient } from '../lib/docker-client.js';
+import { Logger } from '../lib/logs.js';
+
+// Test Docker Exec API functionality
+
+test('should execute ps command in running container and capture output', async () => {
+    const client = await DockerClient.fromDockerConfig();
+    let containerId: string | undefined;
+
+    try {
+        // Pull alpine image first
+        console.log('  Pulling alpine image...');
+        await client.imageCreate(
+            (event) => {
+                if (event.status) console.log(`    ${event.status}`);
+            },
+            {
+                fromImage: 'docker.io/library/alpine',
+                tag: 'latest',
+            },
+        );
+
+        // Create container with sleep infinity to keep it running
+        console.log('  Creating Alpine container with sleep infinity...');
+        const createResponse = await client.containerCreate({
+            Image: 'docker.io/library/alpine:latest',
+            Cmd: ['sleep', 'infinity'],
+            Labels: {
+                'test.type': 'exec-test',
+            },
+        });
+
+        containerId = createResponse.Id;
+        assert.isNotNull(containerId);
+        console.log(`    Container created: ${containerId.substring(0, 12)}`);
+
+        // Start the container
+        console.log('  Starting container...');
+        await client.containerStart(containerId);
+        console.log('    Container started');
+
+        // Create exec instance for 'ps' command
+        console.log('  Creating exec instance for ps command...');
+        const execResponse = await client.containerExec(containerId, {
+            AttachStdout: true,
+            AttachStderr: true,
+            Cmd: ['ps'],
+        });
+
+        const execId = execResponse.Id;
+        assert.isNotNull(execId);
+        console.log(`    Exec instance created: ${execId.substring(0, 12)}`);
+
+        // Set up streams to capture output
+        const stdoutData: string[] = [];
+        const stderrData: string[] = [];
+
+        const stdoutLogger = new Logger((line: string) => {
+            stdoutData.push(line);
+        });
+
+        const stderrLogger = new Logger((line: string) => {
+            stderrData.push(line);
+        });
+
+        // Start exec instance with stream capture
+        console.log('  Starting exec instance...');
+        await client.execStart(execId, stdoutLogger, stderrLogger);
+        console.log('    Exec completed');
+
+        // Verify the output
+        console.log('  Verifying output...');
+        console.log(`    Captured stdout data: ${JSON.stringify(stdoutData)}`);
+        console.log(`    Captured stderr data: ${JSON.stringify(stderrData)}`);
+
+        // Check that we received process information in stdout
+        const allStdout = stdoutData.join('\n');
+        assert.include(
+            allStdout,
+            'sleep',
+            'Should find sleep process in ps output',
+        );
+
+        // Inspect the exec instance to verify it completed successfully
+        console.log('  Inspecting exec instance...');
+        const execInfo = await client.execInspect(execId);
+        console.log(`    Exec exit code: ${execInfo.ExitCode}`);
+
+        assert.equal(execInfo.ExitCode, 0, 'Exec should complete successfully');
+        assert.equal(
+            execInfo.Running,
+            false,
+            'Exec should not be running anymore',
+        );
+
+        console.log('    ✓ Test passed: exec lifecycle completed successfully');
+    } finally {
+        // Clean up: delete container
+        if (containerId) {
+            console.log('  Cleaning up container...');
+            try {
+                await client.containerDelete(containerId, { force: true });
+                console.log('    Container deleted');
+            } catch (error) {
+                console.warn(
+                    `    Warning: Failed to delete container: ${error}`,
+                );
+            }
+        }
+
+        // Close client connection
+        await client.close();
+        console.log('  Client connection closed');
+    }
+});


### PR DESCRIPTION
**- What I did**

Added support for attached mode in execStart
Also fixed https://github.com/docker/node-sdk/issues/31 as `containerAttach` has to wait for socket to close to detect end of streams

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog
Added support for attached mode in execStart with optional stdout/stderr Writable
```

**- A picture of a cute animal (not mandatory but encouraged)**
