### PR TITLE
redesign json-stream functions to rely on AsyncGenerator

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ $ npm version x.y.z
 vx.y.z
 
 # push to git
-$ git push main vx.y.z 
+$ git push main vx.y.z
 ```
 
 GitHub workflow will take care of the rest.

--- a/test-integration/esm-project/main.ts
+++ b/test-integration/esm-project/main.ts
@@ -1,6 +1,7 @@
 import { DockerClient } from '@docker/node-sdk';
 import { createWriteStream } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { Writable } from 'node:stream';
 
 try {
     const docker = await DockerClient.fromDockerConfig();
@@ -20,7 +21,7 @@ try {
         });
 
     const out = createWriteStream(tmpdir() + '/test.tar');
-    await docker.containerExport(ctr, out);
+    await docker.containerExport(ctr, Writable.toWeb(out));
 
     await docker.close();
 } catch (error: any) {

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -13,15 +13,12 @@ test('should receive container stdout on attach', async () => {
     try {
         // Pull alpine image first
         console.log('  Pulling alpine image...');
-        await client.imageCreate(
-            (event) => {
-                if (event.status) console.log(`    ${event.status}`);
-            },
-            {
-                fromImage: 'docker.io/library/alpine',
-                tag: 'latest',
-            },
-        );
+        for await (const event of client.imageCreate({
+            fromImage: 'docker.io/library/alpine',
+            tag: 'latest',
+        })) {
+            if (event.status) console.log(`    ${event.status}`);
+        }
 
         // Create container with echo command
         console.log('  Creating Alpine container with echo command...');
@@ -114,15 +111,12 @@ test('should collect container output using containerLogs', async () => {
     try {
         // Pull alpine image first (should be cached from previous test)
         console.log('  Pulling alpine image...');
-        await client.imageCreate(
-            (event) => {
-                if (event.status) console.log(`    ${event.status}`);
-            },
-            {
-                fromImage: 'docker.io/library/alpine',
-                tag: 'latest',
-            },
-        );
+        for await (const event of client.imageCreate({
+            fromImage: 'docker.io/library/alpine',
+            tag: 'latest',
+        })) {
+            if (event.status) console.log(`    ${event.status}`);
+        }
 
         // Create container with a command that produces multiple lines of output
         console.log('  Creating Alpine container with multi-line output...');
@@ -252,15 +246,12 @@ test('container lifecycle should work end-to-end', async () => {
     let containerId: string | undefined;
 
     try {
-        await client.imageCreate(
-            (event) => {
-                console.log(event);
-            },
-            {
-                fromImage: 'docker.io/library/nginx',
-                tag: 'latest',
-            },
-        );
+        for await (const event of client.imageCreate({
+            fromImage: 'docker.io/library/nginx',
+            tag: 'latest',
+        })) {
+            console.log(event);
+        }
 
         console.log('  Creating nginx container...');
         // Create container with label

--- a/test/exec.test.ts
+++ b/test/exec.test.ts
@@ -11,15 +11,12 @@ test('should execute ps command in running container and capture output', async 
     try {
         // Pull alpine image first
         console.log('  Pulling alpine image...');
-        await client.imageCreate(
-            (event) => {
-                if (event.status) console.log(`    ${event.status}`);
-            },
-            {
-                fromImage: 'docker.io/library/alpine',
-                tag: 'latest',
-            },
-        );
+        for await (const event of client.imageCreate({
+            fromImage: 'docker.io/library/alpine',
+            tag: 'latest',
+        })) {
+            if (event.status) console.log(`    ${event.status}`);
+        }
 
         // Create container with sleep infinity to keep it running
         console.log('  Creating Alpine container with sleep infinity...');

--- a/test/image.test.ts
+++ b/test/image.test.ts
@@ -12,15 +12,12 @@ test('image lifecycle: create container, commit image, export/import, inspect, a
     try {
         // Step 1: Pull alpine image and create container
         console.log('  Pulling alpine image...');
-        await client.imageCreate(
-            (event) => {
-                if (event.status) console.log(`    ${event.status}`);
-            },
-            {
-                fromImage: 'docker.io/library/alpine',
-                tag: 'latest',
-            },
-        );
+        for await (const event of client.imageCreate({
+            fromImage: 'docker.io/library/alpine',
+            tag: 'latest',
+        })) {
+            if (event.status) console.log(`    ${event.status}`);
+        }
 
         console.log('  Creating Alpine container...');
         const createResponse = await client.containerCreate({


### PR DESCRIPTION
**- What I did**

replace use of a callback with an AsyncGenerator in json-stream APIs

**- How I did it**

claude.ai

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog
systemEvents, imagePush, imageCreate and imageBuild return an AsyncGenerator with JSONMessages
```

**- A picture of a cute animal (not mandatory but encouraged)**
