### PR TITLE
introduce JSONMessage to consumer JSON stream or just wait for operation to complete

### DIFF
--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -19,24 +19,16 @@ COPY test.txt /test.txt
         pack.entry({ name: 'test.txt' }, 'Hello from Docker build test!');
         pack.finalize();
 
-        let builtImage: string | undefined;
-
-        for await (const buildInfo of client.imageBuild(
-            Readable.toWeb(pack, { strategy: { highWaterMark: 16384 } }),
-            {
-                tag: `${testImageName}:${testTag}`,
-                rm: true,
-                forcerm: true,
-            },
-        )) {
-            console.log(`    Build event: ${JSON.stringify(buildInfo)}`);
-            // Capture the built image ID when buildinfo.id == 'moby.image.id'
-            if (buildInfo.id === 'moby.image.id') {
-                builtImage = buildInfo.aux?.ID;
-            }
-        }
-
-        expect(builtImage).toBeDefined();
+        const builtImage = await client
+            .imageBuild(
+                Readable.toWeb(pack, { strategy: { highWaterMark: 16384 } }),
+                {
+                    tag: `${testImageName}:${testTag}`,
+                    rm: true,
+                    forcerm: true,
+                },
+            )
+            .wait();
 
         // Inspect the built builtImage to confirm it was created successfully
         console.log(`  Inspecting built image ${builtImage}`);

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -13,17 +13,17 @@ test('should receive container stdout on attach', async () => {
     try {
         // Pull alpine image first
         console.log('  Pulling alpine image...');
-        for await (const event of client.imageCreate({
-            fromImage: 'docker.io/library/alpine',
-            tag: 'latest',
-        })) {
-            if (event.status) console.log(`    ${event.status}`);
-        }
+        await client
+            .imageCreate({
+                fromImage: 'alpine',
+                tag: 'latest',
+            })
+            .wait();
 
         // Create container with echo command
         console.log('  Creating Alpine container with echo command...');
         const createResponse = await client.containerCreate({
-            Image: 'docker.io/library/alpine:latest',
+            Image: 'alpine',
             Cmd: ['echo', 'hello'],
             Labels: {
                 'test.type': 'container-test',
@@ -111,17 +111,17 @@ test('should collect container output using containerLogs', async () => {
     try {
         // Pull alpine image first (should be cached from previous test)
         console.log('  Pulling alpine image...');
-        for await (const event of client.imageCreate({
-            fromImage: 'docker.io/library/alpine',
-            tag: 'latest',
-        })) {
-            if (event.status) console.log(`    ${event.status}`);
-        }
+        await client
+            .imageCreate({
+                fromImage: 'alpine',
+                tag: 'latest',
+            })
+            .wait();
 
         // Create container with a command that produces multiple lines of output
         console.log('  Creating Alpine container with multi-line output...');
         const createResponse = await client.containerCreate({
-            Image: 'docker.io/library/alpine:latest',
+            Image: 'alpine',
             Cmd: ['sh', '-c', 'echo "line1"; echo "line2"; echo "line3"'],
             Labels: {
                 'test.type': 'container-logs-test',
@@ -246,18 +246,18 @@ test('container lifecycle should work end-to-end', async () => {
     let containerId: string | undefined;
 
     try {
-        for await (const event of client.imageCreate({
-            fromImage: 'docker.io/library/nginx',
-            tag: 'latest',
-        })) {
-            console.log(event);
-        }
+        await client
+            .imageCreate({
+                fromImage: 'nginx',
+                tag: 'latest',
+            })
+            .wait();
 
         console.log('  Creating nginx container...');
         // Create container with label
         const createResponse = await client.containerCreate(
             {
-                Image: 'docker.io/library/nginx',
+                Image: 'nginx',
                 Labels: {
                     'test.type': 'e2e',
                 },

--- a/test/exec.test.ts
+++ b/test/exec.test.ts
@@ -11,17 +11,17 @@ test('should execute ps command in running container and capture output', async 
     try {
         // Pull alpine image first
         console.log('  Pulling alpine image...');
-        for await (const event of client.imageCreate({
-            fromImage: 'docker.io/library/alpine',
-            tag: 'latest',
-        })) {
-            if (event.status) console.log(`    ${event.status}`);
-        }
+        await client
+            .imageCreate({
+                fromImage: 'alpine',
+                tag: 'latest',
+            })
+            .wait();
 
         // Create container with sleep infinity to keep it running
         console.log('  Creating Alpine container with sleep infinity...');
         const createResponse = await client.containerCreate({
-            Image: 'docker.io/library/alpine:latest',
+            Image: 'alpine',
             Cmd: ['sleep', 'infinity'],
             Labels: {
                 'test.type': 'exec-test',

--- a/test/image.test.ts
+++ b/test/image.test.ts
@@ -12,16 +12,16 @@ test('image lifecycle: create container, commit image, export/import, inspect, a
     try {
         // Step 1: Pull alpine image and create container
         console.log('  Pulling alpine image...');
-        for await (const event of client.imageCreate({
-            fromImage: 'docker.io/library/alpine',
-            tag: 'latest',
-        })) {
-            if (event.status) console.log(`    ${event.status}`);
-        }
+        await client
+            .imageCreate({
+                fromImage: 'alpine',
+                tag: 'latest',
+            })
+            .wait();
 
         console.log('  Creating Alpine container...');
         const createResponse = await client.containerCreate({
-            Image: 'docker.io/library/alpine:latest',
+            Image: 'alpine',
             Cmd: ['echo', 'test container'],
             Labels: {
                 'test.type': 'image-test',


### PR DESCRIPTION
**- What I did**

introduce JSONMessage to consumer JSON stream or just wait for operation to complete

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog
`imageBuild`, `imageCreate` and `imagePush` return `JSONMessages`, which can be used to either consume `messages()`, or just `wait()` for operation to complete
```

**- A picture of a cute animal (not mandatory but encouraged)**
