### PR TITLE
improve usability by guessing API options based on defined parameters

### DIFF
--- a/lib/docker-client.ts
+++ b/lib/docker-client.ts
@@ -478,7 +478,11 @@ export class DockerClient {
     ): Promise<void> {
         const response = await this.api.upgrade(
             `/containers/${id}/attach`,
-            options,
+            options || {
+                stdout: stdout != null,
+                stderr: stderr != null,
+                stream: stdout != null || stderr != null,
+            },
         );
         switch (response.content) {
             case DOCKER_RAW_STREAM:
@@ -1641,6 +1645,18 @@ export class DockerClient {
         stderr: stream.Writable | null,
         execStartConfig?: types.ExecStartConfig,
     ): Promise<void> {
+        // If no output streams and Detach not explicitly set, force detached mode
+        if (
+            stdout === null &&
+            stderr === null &&
+            execStartConfig?.Detach === undefined
+        ) {
+            await this.api.post(`/exec/${id}/start`, {
+                ...execStartConfig,
+                Detach: true,
+            });
+            return;
+        }
         if (execStartConfig?.Detach) {
             await this.api.post(`/exec/${id}/start`, execStartConfig);
         } else {


### PR DESCRIPTION
**- What I did**

guess Attach `stdout`, `stderr` or `stream` flags must be set if parameter is defined to collect those.
closes https://github.com/docker/node-sdk/issues/62

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog
improve usability by guessing API options based on defined parameters
```

**- A picture of a cute animal (not mandatory but encouraged)**
