### PR TITLE
chore: simplify dependencies

### DIFF
--- a/lib/ssh.ts
+++ b/lib/ssh.ts
@@ -2,7 +2,6 @@ import { Socket } from 'node:net';
 import { promises as fsPromises } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { Client } from 'ssh2';
 
 /**
  * SSH connection utilities for Docker remote access
@@ -77,6 +76,8 @@ export class SSH {
         } else {
             host = hostPortPart;
         }
+
+        const { Client } = await import('ssh2');
 
         // Return factory function that creates new SSH connections
         return () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
             "version": "0.0.17",
             "license": "Apache-2.0",
             "dependencies": {
-                "ssh2": "^1.16.0",
-                "tar-stream": "^3.1.4",
                 "undici": "^6.22.0"
             },
             "devDependencies": {
@@ -21,12 +19,16 @@
                 "oxlint": "^1.16.0",
                 "oxlint-tsgolint": "^0.2.0",
                 "prettier": "^3.6.2",
+                "tar-stream": "^3.1.4",
                 "tsdown": "^0.15.6",
                 "tsx": "^4.20.6",
                 "typescript": "^5.9.2"
             },
             "engines": {
                 "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "peerDependencies": {
+                "ssh2": "^1.16.0"
             }
         },
         "node_modules/@babel/generator": {
@@ -1581,6 +1583,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
             "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "safer-buffer": "~2.1.0"
             }
@@ -1638,6 +1641,7 @@
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
             "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+            "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
                 "react-native-b4a": "*"
@@ -1652,6 +1656,7 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.0.tgz",
             "integrity": "sha512-AOhh6Bg5QmFIXdViHbMc2tLDsBIRxdkIaIddPslJF9Z5De3APBScuqGP2uThXnIpqFrgoxMNC6km7uXNIMLHXA==",
+            "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
                 "bare-abort-controller": "*"
@@ -1698,6 +1703,7 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
@@ -1754,6 +1760,7 @@
             "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
             "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -2021,6 +2028,7 @@
             "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
             "hasInstallScript": true,
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "buildcheck": "~0.0.6",
                 "nan": "^2.19.0"
@@ -2368,6 +2376,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
             "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "bare-events": "^2.7.0"
@@ -2377,6 +2386,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
             "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-safe-stringify": {
@@ -3085,7 +3095,8 @@
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
             "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/netmask": {
             "version": "2.0.2",
@@ -3701,6 +3712,7 @@
             "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
             "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
             "hasInstallScript": true,
+            "peer": true,
             "dependencies": {
                 "asn1": "^0.2.6",
                 "bcrypt-pbkdf": "^1.0.2"
@@ -3717,6 +3729,7 @@
             "version": "2.23.0",
             "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
             "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "events-universal": "^1.0.0",
@@ -3826,6 +3839,7 @@
             "version": "3.1.7",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
             "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "b4a": "^1.6.4",
@@ -3837,6 +3851,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
             "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
@@ -3996,7 +4011,8 @@
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-            "license": "Unlicense"
+            "license": "Unlicense",
+            "peer": true
         },
         "node_modules/type-fest": {
             "version": "0.21.3",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,10 @@
         "format.check": "prettier --check ."
     },
     "dependencies": {
-        "ssh2": "^1.16.0",
-        "tar-stream": "^3.1.4",
         "undici": "^6.22.0"
+    },
+    "peerDependencies": {
+        "ssh2": "^1.16.0"
     },
     "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.23.4",
@@ -60,6 +61,7 @@
         "oxlint": "^1.16.0",
         "oxlint-tsgolint": "^0.2.0",
         "prettier": "^3.6.2",
+        "tar-stream": "^3.1.4",
         "tsdown": "^0.15.6",
         "tsx": "^4.20.6",
         "typescript": "^5.9.2"


### PR DESCRIPTION
**- What I did**

Removed two dependencies, leaving `undici` as the only required dependency. Cutting the dependency tree from 22 packages to 1 (when [removing the peer dependency](https://pnpm.io/settings#overrides:~:text=If%20you%20find%20that%20your%20use%20of%20a%20certain%20package%20doesn%27t%20require%20one%20of%20its%20dependencies%2C%20you%20may%20use%20%2D%20to%20remove%20it.) `@docker/node-sdk>ssh2: -`).

**- How I did it**

The `tar-stream` dependency is only used in tests. The `ssh2` import has been moved into the async `createSocketFactory` function, allowing the dependency to be moved into peer dependencies (https://github.com/docker/node-sdk/issues/64). npm will [automatically install peer dependencies](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependencies:~:text=peerDependencies%20are%20installed%20by%20default). This means this is not a breaking change sine the ssh feature is still enabled by default.

**- How to verify it**

The existing test suite.

**- Human readable description for the release notes**

```markdown changelog
removed `tar-stream` from dependencies and made `ssh2` a peer dependency
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="8016" height="6032" alt="PXL_20260108_013339845 RAW-02 ORIGINAL" src="https://github.com/user-attachments/assets/3d53ca03-1c37-4f84-8fe3-a31093946290" />
